### PR TITLE
Add ability to check for update

### DIFF
--- a/cmd/aterm/appdialogs/checkupdate.go
+++ b/cmd/aterm/appdialogs/checkupdate.go
@@ -1,0 +1,34 @@
+package appdialogs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/theparanoids/aterm/fancy"
+
+	"github.com/theparanoids/aterm/network"
+)
+
+func NotifyUpdate(currentVersion, owner, repo string) {
+	currentSemVer := network.ParseVersion(currentVersion)
+	if currentSemVer.String() == "v0.0.0-development" {
+		fmt.Println("This appears to be a development release")
+		return
+	}
+
+	res, err := network.CheckVersion(owner, repo, currentSemVer)
+	if err != nil {
+		fmt.Println("Unable to check for updates", err)
+	} else if res.HasUpgrade() {
+		fmt.Println(fancy.AsBold("There is an update available."))
+		if res.MajorUpgrade != nil {
+			upgradeNoticeTemplate.Execute(os.Stdout, NewUpgrade("major", (*res.MajorUpgrade).String(), (*res.MajorRelease).GetHTMLURL()))
+		}
+		if res.MinorUpgrade != nil {
+			upgradeNoticeTemplate.Execute(os.Stdout, NewUpgrade("minor", (*res.MinorUpgrade).String(), (*res.MinorRelease).GetHTMLURL()))
+		}
+		if res.PatchUpgrade != nil {
+			upgradeNoticeTemplate.Execute(os.Stdout, NewUpgrade("patch", (*res.PatchUpgrade).String(), (*res.PatchRelease).GetHTMLURL()))
+		}
+	}
+}

--- a/cmd/aterm/appdialogs/templates.go
+++ b/cmd/aterm/appdialogs/templates.go
@@ -101,3 +101,18 @@ var apiURLFields = AskForTemplateFields{
 	Preamble:     "Where are the ASHIRT servers located? If you don't know, please contact your administrator.",
 	Prompt:       "Enter the API URL",
 }
+
+var upgradeNoticeTemplate = template.Must(fancyTemplate.New("upgradeNotice").Parse(
+	"{{clear}}The latest {{.ReleaseType}} release ({{.Version | bold}}) can be found here: {{.URL | underlined}}" +
+		"\n\r",
+))
+
+type UpgradeNoticeTemplateFields struct {
+	ReleaseType string
+	Version     string
+	URL         string
+}
+
+func NewUpgrade(releaseType, tag, url string) UpgradeNoticeTemplateFields {
+	return UpgradeNoticeTemplateFields{ReleaseType: releaseType, Version: tag, URL: url}
+}

--- a/cmd/aterm/climain.go
+++ b/cmd/aterm/climain.go
@@ -51,6 +51,9 @@ func main() {
 		return
 	}
 
+	// TOOD: replace version, owner, repo with real values
+	appdialogs.NotifyUpdate("v30.0.0", "google", "go-github")
+
 	recording.InitializeRecordings()
 
 	menuState := appdialogs.MenuState{

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/OpenPeeDeeP/xdg v1.0.0
 	github.com/creack/pty v1.1.11
+	github.com/google/go-github/v32 v32.1.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/jonboulle/clockwork v0.1.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/OpenPeeDeeP/xdg v1.0.0
 	github.com/creack/pty v1.1.11
+	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-github/v32 v32.1.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/jonboulle/clockwork v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,11 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
+github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
 github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/network/github.go
+++ b/network/github.go
@@ -1,0 +1,171 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/google/go-github/v32/github"
+)
+
+var latestOption = github.ListOptions{
+	Page:    1,
+	PerPage: 1,
+}
+
+var last30Option = github.ListOptions{
+	Page:    1,
+	PerPage: 30,
+}
+
+var githubClient *github.Client = github.NewClient(nil)
+var semver2Regex = regexp.MustCompile(`^[vV]?(\d+)\.(\d+)\.(\d+)(.*)`)
+
+// SemVer is a *loose* interpertation of Semantic Versioning (v2). Details are here:
+// https://semver.org/spec/v2.0.0.html
+// In general, this structure tries to capture the core details: a major, minor, patch, and "extra"
+// section covering usage to try to find new versions. It is incumbent on the user to parse the "extra"
+// if more details are needed beyond the Major/Minor/Patch versions
+type SemVer struct {
+	Major int
+	Minor int
+	Patch int
+	Extra string
+}
+
+// NewSemVer constructs a new semver
+func NewSemVer(ma, mi, pa int, ex string) SemVer {
+	return SemVer{Major: ma, Minor: mi, Patch: pa, Extra: ex}
+}
+
+// String reconstructs a semver string 
+func (s SemVer) String() string {
+	return fmt.Sprintf("v%v.%v.%v%v", s.Major, s.Minor, s.Patch, s.Extra)
+}
+
+type UpgradeResult struct {
+	MajorUpgrade *SemVer
+	MajorRelease *github.RepositoryRelease
+	MinorUpgrade *SemVer
+	MinorRelease *github.RepositoryRelease
+	PatchUpgrade *SemVer
+	PatchRelease *github.RepositoryRelease
+}
+
+// HasUpgrade checks if some major, minor, or patch version has been set in the given UpgradeResult
+func (u UpgradeResult) HasUpgrade() bool {
+	return u.MajorUpgrade != nil || u.MinorUpgrade != nil || u.PatchUpgrade != nil
+}
+
+// CheckVersion retrieves the current releases, then calls CheckVersionUpdate on those releases
+func CheckVersion(owner, repo string, current SemVer) (UpgradeResult, error) {
+	releases, err := RecentReleases(owner, repo)
+	if err != nil {
+		return UpgradeResult{}, err
+	}
+	return CheckVersionUpdate(current, releases), nil
+
+}
+
+// CheckVersionUpdate iterates through the provided list of releases, and determines which, if any,
+// are "upgrades" (ignoring any "extra" bits in the semver). An UpgradeResult is returned, indicating
+// which kind of upgrades are available.
+func CheckVersionUpdate(current SemVer, releases []*github.RepositoryRelease) UpgradeResult {
+	up := UpgradeResult{}
+
+	first := func(b bool, _ SemVer) bool { return b }
+
+	for _, r := range releases {
+		parsedTag := ParseVersion(r.GetTagName())
+		if parsedTag.Major > current.Major {
+			if up.MajorUpgrade == nil || first(IsNewerSemVer(*up.MajorUpgrade, parsedTag)) {
+				up.MajorUpgrade = &parsedTag
+				up.MajorRelease = r
+			}
+		} else if parsedTag.Major == current.Major && parsedTag.Minor > current.Minor {
+			if up.MinorUpgrade == nil || first(IsNewerSemVer(*up.MinorUpgrade, parsedTag)) {
+				up.MinorUpgrade = &parsedTag
+				up.MinorRelease = r
+			}
+		} else if parsedTag.Major == current.Major && parsedTag.Minor == current.Minor && parsedTag.Patch > current.Patch {
+			if up.PatchUpgrade == nil || first(IsNewerSemVer(*up.PatchUpgrade, parsedTag)) {
+				up.PatchUpgrade = &parsedTag
+				up.PatchRelease = r
+			}
+		}
+	}
+
+	return up
+}
+
+// IsNewerSemVer compares 2 SemVer structs. It will return true if the "next" SemVer has a higher
+// major version, or an equal major version and a higher minor version, or an equal major and minor
+// versions, and a higher patch version (extra is ignored)
+// In addition, this also returns the difference, represented as a semver, of the comparison, which
+// is helpful in determining how the "next" version is newer (or older). Each value in the difference
+// is determined by (next.X - current.X)
+func IsNewerSemVer(current SemVer, next SemVer) (bool, SemVer) {
+	diff := SemVer{
+		Major: next.Major - current.Major,
+		Minor: next.Minor - current.Minor,
+		Patch: next.Patch - current.Patch,
+	}
+	if diff.Major < 0 {
+		return false, diff
+	} else if diff.Minor < 0 && diff.Major == 0 {
+		return false, diff
+	} else if diff.Patch < 1 && diff.Minor == 0 && diff.Major == 0 {
+		return false, diff
+	}
+	return true, diff
+}
+
+// RecentReleases returns the newest 30 releases (currently the max single page value from github)
+// from the specified github repo
+func RecentReleases(owner, repo string) ([]*github.RepositoryRelease, error) {
+	return recentReleases(owner, repo, last30Option)
+}
+
+func recentReleases(owner, repo string, opts github.ListOptions) ([]*github.RepositoryRelease, error) {
+	release, _, err := githubClient.Repositories.ListReleases(context.Background(), owner, repo, &opts)
+
+	return release, err
+}
+
+// LatestRelease returns the newest release from the specified github repo
+func LatestRelease(owner, repo string) (*github.RepositoryRelease, error) {
+	release, err := recentReleases(owner, repo, latestOption)
+
+	return release[0], err
+}
+
+// ParseVersion returns a SemVer for the given Semantic Version string provided.
+// This will match the major, minor, and patch numbers, and provide the remainder as the "extra".
+// the leading v is optional.
+func ParseVersion(tagName string) SemVer {
+	if tagName == "" {
+		return SemVer{}
+	}
+	matches := semver2Regex.FindStringSubmatch(tagName)
+
+	if matches == nil {
+		return SemVer{}
+	}
+
+	maj, majErr := strconv.Atoi(matches[1])
+	min, minErr := strconv.Atoi(matches[2])
+	pat, patErr := strconv.Atoi(matches[3])
+	ext := matches[4]
+
+	if majErr != nil || minErr != nil || patErr != nil {
+		return SemVer{}
+	}
+
+	return SemVer{
+		Major: maj,
+		Minor: min,
+		Patch: pat,
+		Extra: ext,
+	}
+}

--- a/network/github.go
+++ b/network/github.go
@@ -39,7 +39,7 @@ func NewSemVer(ma, mi, pa int, ex string) SemVer {
 	return SemVer{Major: ma, Minor: mi, Patch: pa, Extra: ex}
 }
 
-// String reconstructs a semver string 
+// String reconstructs a semver string
 func (s SemVer) String() string {
 	return fmt.Sprintf("v%v.%v.%v%v", s.Major, s.Minor, s.Patch, s.Extra)
 }

--- a/network/github_test.go
+++ b/network/github_test.go
@@ -1,0 +1,94 @@
+package network_test
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/stretchr/testify/require"
+	"github.com/theparanoids/aterm/network"
+)
+
+func TestSemVerParse(t *testing.T) {
+	// Test invalid versions
+	require.Equal(t, network.SemVer{}, network.ParseVersion(""))
+	require.Equal(t, network.SemVer{}, network.ParseVersion("2"))
+	require.Equal(t, network.SemVer{}, network.ParseVersion("2.0"))
+	require.Equal(t, network.SemVer{}, network.ParseVersion("VA.B.C"))
+
+	// test valid versions
+	require.Equal(t, network.NewSemVer(1, 2, 3, ""), network.ParseVersion("v1.2.3"))
+	require.Equal(t, network.NewSemVer(1, 2, 3, "-extra"), network.ParseVersion("v1.2.3-extra"))
+	require.Equal(t, network.NewSemVer(2, 3, 4, "-double-extra"), network.ParseVersion("v2.3.4-double-extra"))
+	require.Equal(t, network.NewSemVer(9, 8, 7, ""), network.ParseVersion("9.8.7"))
+}
+
+func TestIsNewerSemVer(t *testing.T) {
+	initialVersion := network.ParseVersion("v1.2.3")
+
+	newer, diff := network.IsNewerSemVer(initialVersion, network.ParseVersion("v2.2.3"))
+	require.Equal(t, 1, diff.Major)
+	require.True(t, newer)
+
+	newer, diff = network.IsNewerSemVer(initialVersion, network.ParseVersion("v1.3.3"))
+	require.Equal(t, 1, diff.Minor)
+	require.True(t, newer)
+
+	newer, diff = network.IsNewerSemVer(initialVersion, network.ParseVersion("v1.2.4"))
+	require.Equal(t, 1, diff.Patch)
+	require.True(t, newer)
+
+	newer, diff = network.IsNewerSemVer(initialVersion, network.ParseVersion("v1.2.3"))
+	require.Equal(t, 0, diff.Major)
+	require.Equal(t, 0, diff.Minor)
+	require.Equal(t, 0, diff.Patch)
+	require.False(t, newer)
+
+	newer, diff = network.IsNewerSemVer(initialVersion, network.ParseVersion("v0.2.3"))
+	require.Equal(t, -1, diff.Major)
+	require.False(t, newer)
+
+	newer, diff = network.IsNewerSemVer(initialVersion, network.ParseVersion(""))
+	require.False(t, newer)
+}
+
+func TestCheckVersionUpdate(t *testing.T) {
+	current := network.ParseVersion("v1.2.3")
+
+	outOfDateRelease := mockRelease("v1.2.2", "Out of Date Release", "you shouldn't see this")
+	firstPatch := mockRelease("v1.2.4", "First patch release", "you shouldn't see this either")
+	secondPatch := mockRelease("v1.2.5", "Second patch release", "you should see this")
+	minor := mockRelease("v1.3.0", "Minor Update", "you should also see this")
+	major := mockRelease("v2.0.0", "Major Update", "This should really be present")
+
+	others := []*github.RepositoryRelease{
+		outOfDateRelease,
+		firstPatch,
+		secondPatch,
+		minor,
+		major,
+	}
+
+	res := network.CheckVersionUpdate(current, others)
+
+	require.True(t, res.HasUpgrade())
+	require.Equal(t, network.ParseVersion(secondPatch.GetTagName()), *(res.PatchUpgrade))
+	require.Equal(t, secondPatch, res.PatchRelease)
+	require.Equal(t, network.ParseVersion(minor.GetTagName()), *(res.MinorUpgrade))
+	require.Equal(t, minor, res.MinorRelease)
+	require.Equal(t, network.ParseVersion(major.GetTagName()), *(res.MajorUpgrade))
+	require.Equal(t, major, res.MajorRelease)
+
+	none := []*github.RepositoryRelease{}
+	noneRes := network.CheckVersionUpdate(current, none)
+	require.False(t, noneRes.HasUpgrade())
+}
+
+func mockRelease(tagName, name, body string) *github.RepositoryRelease {
+	r := github.RepositoryRelease{
+		TagName: &tagName,
+		Name:    &name,
+		Body:    &body,
+	}
+
+	return &r
+}


### PR DESCRIPTION
This PR adds the ability to notify the user of new releases. This will not automatically install a new version (nor prevent access for an out-of-date version), but simply alert the user when one is available. 

Depends on: PR #8 (built off of this branch)

Note: this is "complete" and ready for review, except that we currently do not track versions for ATerm. A separate PR providing those values needs to be merged first (see PR #9 )

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.