### PR TITLE
revise connection check to use new endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/theparanoids/ashirt-server v0.0.0-20200708052605-7c5b90cde657
+	github.com/theparanoids/ashirt-server v0.0.0-20200922024650-e7b93c90eb90
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/theparanoids/ashirt-server v0.0.0-20200708052605-7c5b90cde657 h1:yna6n17pONuqLjcyqjfhF51XGBxegZ60ZRcc3e2zBrY=
-github.com/theparanoids/ashirt-server v0.0.0-20200708052605-7c5b90cde657/go.mod h1:sGGnEYzuZj7fr+Viz2k6AuL8HDbL7NJ6skxxLsxeiIE=
+github.com/theparanoids/ashirt-server v0.0.0-20200922024650-e7b93c90eb90 h1:6rKrIdEpM8WvE6OuCpoZ12QqDg8417pYm1p92mh4hME=
+github.com/theparanoids/ashirt-server v0.0.0-20200922024650-e7b93c90eb90/go.mod h1:sGGnEYzuZj7fr+Viz2k6AuL8HDbL7NJ6skxxLsxeiIE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
@@ -384,6 +384,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f h1:68K/z8GLUxV76xGSqwTWw2gyk/jwn79LUL43rES2g8o=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/network/check_connection.go
+++ b/network/check_connection.go
@@ -1,0 +1,42 @@
+package network
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/theparanoids/ashirt-server/backend/dtos"
+)
+
+var ErrConnectionUnauthorized = errors.New("Could not connect: Unauthorized")
+var ErrConnectionNotFound = errors.New("Could not connect: Not Found")
+var ErrConnectionUnknownStatus = errors.New("Could not connect: Unknown status")
+var ErrOutOfDateServer = errors.New("Could not connect: Invalid or out of date server")
+
+// TestConnection performs a basic query to the backend and interprets the results.
+// There are a few scenarios. A successful connection returns ("", nil)
+// Otherwise, the return structure is ("suggestion to fix (if any)", underlyingError)
+// the underlying error is likely (but not necessarily) one of:
+// ErrConnectionUnknownStatus, ErrConnectionNotFound, ErrConnectionUnauthorized
+// use errors.Is(err, target) to check these errors
+func TestConnection() (string, error) {
+	resp, err := makeJSONRequest("GET", apiURL+"/checkconnection", http.NoBody)
+	if err != nil {
+		return "", err
+	}
+	statusCode := resp.StatusCode
+	if statusCode == http.StatusOK {
+		var cc dtos.CheckConnection
+		if err = readResponseBody(&cc, resp.Body); err != nil || cc.Connected == false {
+			return "Check API URL", ErrOutOfDateServer
+		}
+
+		return "", nil
+	} else if statusCode == http.StatusUnauthorized {
+		return "Check API and Secret keys", ErrConnectionUnauthorized
+	} else if statusCode == http.StatusNotFound {
+		return "Check API URL", ErrConnectionNotFound
+	} else {
+		return "", fmt.Errorf("%w : Status Code: %v", ErrConnectionUnknownStatus, statusCode)
+	}
+}

--- a/network/check_connection.go
+++ b/network/check_connection.go
@@ -27,7 +27,7 @@ func TestConnection() (string, error) {
 	statusCode := resp.StatusCode
 	if statusCode == http.StatusOK {
 		var cc dtos.CheckConnection
-		if err = readResponseBody(&cc, resp.Body); err != nil || cc.Connected == false {
+		if err = readResponseBody(&cc, resp.Body); err != nil || cc.Ok == false {
 			return "Check API URL", ErrOutOfDateServer
 		}
 

--- a/network/get_operations.go
+++ b/network/get_operations.go
@@ -4,7 +4,6 @@
 package network
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/theparanoids/ashirt-server/backend/dtos"
@@ -12,9 +11,6 @@ import (
 )
 
 var ErrCannotConnect = errors.New("Unable to connect to the server")
-var ErrConnectionUnauthorized = errors.New("Could not connect: Unauthorized")
-var ErrConnectionNotFound = errors.New("Could not connect: Not Found")
-var ErrConnectionUnknownStatus = errors.New("Could not connect: Unknown status")
 
 // GetOperations retrieves all of the operations that are exposed to backend tools (api routes)
 func GetOperations() ([]dtos.Operation, error) {
@@ -32,27 +28,4 @@ func GetOperations() ([]dtos.Operation, error) {
 	err = readResponseBody(&ops, resp.Body)
 
 	return ops, err
-}
-
-// TestConnection performs a basic query to the backend and interprets the results.
-// There are a few scenarios. A successful connection returns ("", nil)
-// Otherwise, the return structure is ("suggestion to fix (if any)", underlyingError)
-// the underlying error is likely (but not necessarily) one of:
-// ErrConnectionUnknownStatus, ErrConnectionNotFound, ErrConnectionUnauthorized
-// use errors.Is(err, target) to check these errors
-func TestConnection() (string, error) {
-	resp, err := makeJSONRequest("GET", apiURL+"/operations", http.NoBody)
-	if err != nil {
-		return "", err
-	}
-	statusCode := resp.StatusCode
-	if statusCode == http.StatusOK {
-		return "", nil
-	} else if statusCode == http.StatusUnauthorized {
-		return "Check API and Secret keys", ErrConnectionUnauthorized
-	} else if statusCode == http.StatusNotFound {
-		return "Check API URL", ErrConnectionNotFound
-	} else {
-		return "", fmt.Errorf("%w : Status Code: %v", ErrConnectionUnknownStatus, statusCode)
-	}
 }


### PR DESCRIPTION
This PR revises the connection check to instead pull from `/api/checkconnection` rather than `/api/operations`

Depends on PR [60 from ashirt-server](https://github.com/theparanoids/ashirt-server/pull/60)
Uses js-revised-start as a base

Note: untested -- will be tested after ashirt-server PR 60 is merged

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.