### PR TITLE
Add flag to print extended version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ run-version:
 run-reset-hard:
 	go run $(LD_FLAGS) cmd/aterm/*.go -reset-hard
 
+.PHONY: run-help
+run-help:
+	go run $(LD_FLAGS) cmd/aterm/*.go -h
+
 .PHONY: debug
 debug:
 	go run $(LD_FLAGS) cmd/aterm/*.go 2>debug.log

--- a/cmd/aterm/appdialogs/version.go
+++ b/cmd/aterm/appdialogs/version.go
@@ -7,5 +7,11 @@ import (
 // PrintVersion prints a simple sentence that lists the current version and commit hash
 // Note: this should only be called _after_ parsing CLI options
 func PrintVersion() {
-	printfln("ATerm Version: %v  Build Hash: %v", config.Version(), config.CommitHash())
+	printline("ATerm Version:", config.Version(), " Build Hash:", config.CommitHash())
+}
+
+// PrintExtendedVersion prints more version information: the go runtime and the build date
+// Note: this should only be called _after_ parsing CLI options
+func PrintExtendedVersion() {
+	printline("Go runtime:", config.GoRuntime(), " Build Date:", config.BuildDate())
 }

--- a/cmd/aterm/climain.go
+++ b/cmd/aterm/climain.go
@@ -21,7 +21,8 @@ func main() {
 
 	appdialogs.PrintVersion()
 
-	if info.Flag() {
+	if info.Flag() || opts.PrintVersion {
+		appdialogs.PrintExtendedVersion()
 		return // exit if they ask to print the version
 	}
 

--- a/cmd/aterm/config/cli_parser.go
+++ b/cmd/aterm/config/cli_parser.go
@@ -14,6 +14,7 @@ type CLIOptions struct {
 	PrintConfig          bool
 	ForceFirstRun        bool
 	HardReset            bool
+	PrintVersion         bool
 }
 
 // ParseCLI parses all (supported) arguments from the command line and stores them in a CLIOptions
@@ -27,7 +28,7 @@ func ParseCLI() CLIOptions {
 	attachBoolFlag("print-config", "pc", "Print current configuration (post-command line arguments), then exits", false, &opts.PrintConfig)
 	attachBoolFlag("reset", "", "Rerun first run to set up initial values", false, &opts.ForceFirstRun)
 	attachBoolFlag("reset-hard", "", "Ignore the config file and rerun first run", false, &opts.HardReset)
-
+	attachBoolFlag("v", "", "output the software version and build information", false, &opts.PrintVersion)
 	flag.Parse()
 	return opts
 }


### PR DESCRIPTION
This PR extends the -version flag to now also print the build date and go runtime, in addition to the standard version/build hash that always prints on startup. This also adds in a `-v` flag that does the same. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.